### PR TITLE
Ignore tests for tag builds

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2833,12 +2833,16 @@ function run() {
         core.exportVariable('BROWSER_STACK_PROJECT', core.getInput('browser-stack-project') || process.env.GITHUB_REPOSITORY);
         yield install();
         yield installCerts();
-        yield coverage();
         yield build();
-        yield visual();
-        yield buildLibrary();
+        // Don't run tests for tags.
         if (utils_1.isTag()) {
+            yield buildLibrary();
             yield publishLibrary();
+        }
+        else {
+            yield coverage();
+            yield visual();
+            yield buildLibrary();
         }
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,13 +122,16 @@ async function run(): Promise<void> {
 
   await install();
   await installCerts();
-  await coverage();
   await build();
-  await visual();
-  await buildLibrary();
 
+  // Don't run tests for tags.
   if (isTag()) {
+    await buildLibrary();
     await publishLibrary();
+  } else {
+    await coverage();
+    await visual();
+    await buildLibrary();
   }
 }
 


### PR DESCRIPTION
This should reduce the number of BrowserStack sessions we create when a release PR is merged.