### PR TITLE
Fix package vulnerability warnings

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/Erbium

--- a/dist/index.js
+++ b/dist/index.js
@@ -7209,6 +7209,12 @@ function convertBody(buffer, headers) {
 	// html4
 	if (!res && str) {
 		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+		if (!res) {
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\3/i.exec(str);
+			if (res) {
+				res.pop(); // drop last quote
+			}
+		}
 
 		if (res) {
 			res = /charset=(.*)/i.exec(res.pop());
@@ -8216,7 +8222,7 @@ function fetch(url, opts) {
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
 					case 'error':
-						reject(new FetchError(`redirect mode is set to error: ${request.url}`, 'no-redirect'));
+						reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${request.url}`, 'no-redirect'));
 						finalize();
 						return;
 					case 'manual':
@@ -8255,7 +8261,8 @@ function fetch(url, opts) {
 							method: request.method,
 							body: request.body,
 							signal: request.signal,
-							timeout: request.timeout
+							timeout: request.timeout,
+							size: request.size
 						};
 
 						// HTTP-redirect fetch step 9

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-mwpoNjHSWWh0IiALdDEQi3tru124JKn0yVNziIBzTME8QRv7thwoghVuT1jBRjFvdtoHsqD58IRHy1nf86paRg=="
     },
     "@actions/github": {
       "version": "4.0.0",
@@ -452,9 +452,9 @@
       }
     },
     "@types/jasmine": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.11.tgz",
-      "integrity": "sha512-fg1rOd/DehQTIJTifGqGVY6q92lDgnLfs7C6t1ccSwQrMyoTGSoH6wWzhJDZb6ezhsdwAX4EIBLe8w5fXWmEng==",
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.14.tgz",
+      "integrity": "sha512-Fkgk536sHPqcOtd+Ow+WiUNuk0TSo/BntKkF8wSvcd6M2FvPjeXcUE6Oz/bwDZiUZEaXLslAgw00Q94Pnx6T4w==",
       "dev": true
     },
     "@types/minimatch": {
@@ -1228,9 +1228,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-preload": {
       "version": "0.2.1",
@@ -1567,9 +1567,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.2.tgz",
-      "integrity": "sha512-UyNrLdK3E0fQG/xWNqAFAC5ugtFyPO4JJR1KyyfQAyzR8W0fTRrC91A8Wej4BntFzcvETdCSDa/4PnNYJQLYiA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1583,7 +1583,7 @@
         "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.10.0",
+        "tslib": "^1.13.0",
         "tsutils": "^2.29.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Blackbaud, Inc.",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "1.2.4",
+    "@actions/core": "1.2.5",
     "@actions/github": "4.0.0",
     "@slack/webhook": "5.0.3"
   },
@@ -24,7 +24,7 @@
     "@istanbuljs/nyc-config-typescript": "1.0.1",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
-    "@types/jasmine": "3.5.11",
+    "@types/jasmine": "3.5.14",
     "@types/rimraf": "3.0.0",
     "@zeit/ncc": "0.22.3",
     "cross-spawn": "7.0.3",
@@ -33,7 +33,7 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-node": "8.10.2",
-    "tslint": "6.1.2",
+    "tslint": "6.1.3",
     "typescript": "3.9.5"
   }
 }


### PR DESCRIPTION
- Use Node.js 12+
- Upgrade vulnerable packages.
- Reran `npm run build && npm run pack`.